### PR TITLE
Fix Maven dependency resolution for Paper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,13 @@
         </dependency>
     </dependencies>
 
+    <repositories>
+        <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+    </repositories>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
## Summary
- add PaperMC repository to `pom.xml`

## Testing
- `mvn -q test` *(fails: PluginResolutionException, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687bf64d9558832cbd7d746ac6498a3a